### PR TITLE
Enable guest cart and login redirects

### DIFF
--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import axios from 'axios';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
@@ -17,6 +17,8 @@ export default function LoginPage() {
   const [user, setUser] = useState<any>(null);
   const [token, setToken] = useState<string | null>(null);
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectPath = searchParams.get('redirect');
 
   const API_URL = `https://api.teenzskin.com/api/v1/auth/signin`;
 
@@ -56,7 +58,9 @@ export default function LoginPage() {
 
         const role = data.user.role?.toUpperCase();
         setTimeout(() => {
-          if (role === 'ADMIN') {
+          if (redirectPath) {
+            router.push(redirectPath);
+          } else if (role === 'ADMIN') {
             router.push('/admin');
           } else {
             router.push('/account/profile');

--- a/frontend/src/app/cart/page.tsx
+++ b/frontend/src/app/cart/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { ShoppingBag, Trash2, Plus, Minus, ArrowRight } from 'lucide-react';
 import { useCartStore } from '@/lib/store';
 import Button from '@/components/ui/Button';
@@ -12,6 +13,7 @@ import { toast } from 'react-hot-toast';
 export default function CartPage() {
   const { items, removeItem, updateQuantity, getTotal, getItemCount } = useCartStore();
   const [isUpdating, setIsUpdating] = useState(false);
+  const router = useRouter();
 
   const handleQuantityChange = async (productId: string, currentQuantity: number, delta: number) => {
     setIsUpdating(true);
@@ -195,6 +197,11 @@ export default function CartPage() {
                     if (getItemCount() === 0) {
                       e.preventDefault();
                       toast.error('Please add items to cart before checkout');
+                      return;
+                    }
+                    if (!localStorage.getItem('token')) {
+                      e.preventDefault();
+                      router.push('/auth/login?redirect=/checkout');
                     }
                   }}
                 >

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -46,6 +46,12 @@ function CheckoutPage() {
     const fetchData = async () => {
       setIsLoading(true);
       try {
+        const tokenCheck = localStorage.getItem('token');
+        if (!tokenCheck) {
+          toast.error('Please login to continue');
+          router.push('/auth/login?redirect=/checkout');
+          return;
+        }
 
         const mode = searchParams.get('mode');
         if (mode === 'buy_now') {
@@ -64,7 +70,7 @@ function CheckoutPage() {
           }
         }
 
-        const token = localStorage.getItem('token');
+        const token = tokenCheck;
         if (token) {
           const userRes = await fetch('https://api.teenzskin.com/api/v1/user/me', {
             headers: { Authorization: `Bearer ${token}` }

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -23,20 +23,13 @@ interface CartStore {
   getSelectedItems: () => CartItem[];
 }
 
-const isAuthenticated = () => {
-  if (typeof window === 'undefined') return false;
-  return !!localStorage.getItem('token');
-};
+
 
 export const useCartStore = create<CartStore>()(
   persist(
     (set, get) => ({
       items: [],
       addItem: async (product, quantity = 1) => {
-        if (!isAuthenticated()) {
-          set({ items: [] });
-          return;
-        }
         set((state) => {
           const existingItem = state.items.find(
             (item) => item.product.id === product.id
@@ -58,17 +51,12 @@ export const useCartStore = create<CartStore>()(
         });
       },
       removeItem: async (productId) => {
-        if (!isAuthenticated()) {
-          set({ items: [] });
-          return;
-        }
         set((state) => ({
           items: state.items.filter((item) => item.product.id !== productId),
         }));
       },
       updateQuantity: async (productId, quantity) => {
-        if (!isAuthenticated() || quantity < 1) {
-          set({ items: [] });
+        if (quantity < 1) {
           return;
         }
         
@@ -79,10 +67,6 @@ export const useCartStore = create<CartStore>()(
         }));
       },
       toggleItemSelection: (productId) => {
-        if (!isAuthenticated()) {
-          set({ items: [] });
-          return;
-        }
         set((state) => ({
           items: state.items.map((item) =>
             item.product.id === productId
@@ -92,26 +76,17 @@ export const useCartStore = create<CartStore>()(
         }));
       },
       selectAllItems: () => {
-        if (!isAuthenticated()) {
-          set({ items: [] });
-          return;
-        }
         set((state) => ({
           items: state.items.map((item) => ({ ...item, selected: true })),
         }));
       },
       unselectAllItems: () => {
-        if (!isAuthenticated()) {
-          set({ items: [] });
-          return;
-        }
         set((state) => ({
           items: state.items.map((item) => ({ ...item, selected: false })),
         }));
       },
       clearCart: () => set({ items: [] }),
       getTotal: () => {
-        if (!isAuthenticated()) return 0;
         const items = get().items;
         return items.reduce(
           (total, item) => total + item.product.price * item.quantity,
@@ -119,7 +94,6 @@ export const useCartStore = create<CartStore>()(
         );
       },
       getSelectedTotal: () => {
-        if (!isAuthenticated()) return 0;
         const items = get().items;
         return items
           .filter((item) => item.selected)
@@ -129,12 +103,10 @@ export const useCartStore = create<CartStore>()(
           );
       },
       getItemCount: () => {
-        if (!isAuthenticated()) return 0;
         const items = get().items;
         return items.reduce((count, item) => count + item.quantity, 0);
       },
       getSelectedItems: () => {
-        if (!isAuthenticated()) return [];
         return get().items.filter((item) => item.selected);
       },
     }),


### PR DESCRIPTION
## Summary
- allow cart functionality without requiring authentication
- redirect to intended page after login
- prompt login before checkout
- push user to login when checking out from cart if not signed in

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ff221de288323999dd3fd3c761fae