### PR TITLE
Add user profile update with image

### DIFF
--- a/backend/src/routes/user/userRoutes.ts
+++ b/backend/src/routes/user/userRoutes.ts
@@ -1,11 +1,15 @@
 import express from 'express';
-import { getAllUsers, getCurrentUser } from '../../controller/user/userController';
+import { getAllUsers, getCurrentUser, updateUserProfile } from '../../controller/user/userController';
 import { authenticate } from '../../middlewares/authMiddelware';
+import multer from 'multer';
+
+const upload = multer();
 
 
 const router = express.Router();
 
 router.get('/admin/users',getAllUsers )
 router.get('/user/me',authenticate, getCurrentUser )
+router.put('/user/profile', authenticate, upload.single('profilePicture'), updateUserProfile)
 
 export default router;


### PR DESCRIPTION
## Summary
- add Cloudinary upload when user updates their profile
- enable profile update route
- update Account Profile page to edit name, email, and picture

## Testing
- `npm run build` (frontend) *(fails: `next` not found)*
- `npm run build` (backend) *(fails: `rimraf` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860033ebb2c8323a6a50cc5b7a84d45