### PR TITLE
Add password reset support

### DIFF
--- a/backend/src/controller/auth/forgotPasswordController.ts
+++ b/backend/src/controller/auth/forgotPasswordController.ts
@@ -45,7 +45,7 @@ export const forgotPassword = async (req: Request, res: Response) => {
 
     console.log("Reset link:", resetLink);
 
-    await sendResetEmail(user.email, "Password Reset");
+    await sendResetEmail(user.email, resetLink);
 
     res.status(200).json({
       message: "Password reset link has been sent to your email.",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import { customValidationResult, getErrorMessage, getErrorStack } from "./utils/
 
 import { CONFIG } from "./config";
 import signinRoute from "./routes/auth/signinRoute";
+import forgotRoute from "./routes/auth/forgotRoute";
 
 dotenv.config();
 
@@ -44,6 +45,7 @@ app.get("/", (req, res) => {
 });
 
 app.use("/api/v1/auth", signinRoute);
+app.use("/api/v1/auth", forgotRoute);
 // app.use("/api/v1", publicRouter);
 
 app.use("/api/v1", apiRouter);

--- a/frontend/src/app/auth/reset-password/page.tsx
+++ b/frontend/src/app/auth/reset-password/page.tsx
@@ -1,41 +1,53 @@
 'use client';
 
 import { useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
-import { Mail, ArrowLeft } from 'lucide-react';
+import { Lock, ArrowLeft } from 'lucide-react';
 import Button from '@/components/ui/Button';
 
-export default function ForgotPasswordPage() {
-  const [email, setEmail] = useState('');
+export default function ResetPasswordPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get('token') || '';
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [error, setError] = useState('');
 
   const API_URL = process.env.NEXT_PUBLIC_API_URL
-    ? `${process.env.NEXT_PUBLIC_API_URL}/auth/forgot-password`
-    : 'https://api.teenzskin.com/api/v1/auth/forgot-password';
+    ? `${process.env.NEXT_PUBLIC_API_URL}/auth/reset-password`
+    : 'https://api.teenzskin.com/api/v1/auth/reset-password';
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    setIsLoading(true);
 
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    setIsLoading(true);
     try {
       const res = await fetch(API_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ token, newPassword: password }),
       });
 
       const data = await res.json();
       if (!res.ok) {
-        throw new Error(data?.error || 'Failed to send reset email');
+        throw new Error(data?.error || 'Failed to reset password');
       }
 
       setIsSuccess(true);
+      setTimeout(() => router.push('/auth/login'), 1000);
     } catch (err: any) {
-      setError(err.message || 'Failed to send reset email');
+      setError(err.message || 'Failed to reset password');
     } finally {
       setIsLoading(false);
     }
@@ -59,9 +71,9 @@ export default function ForgotPasswordPage() {
             </Link>
 
             <div className="text-center mb-8">
-              <h1 className="text-2xl font-bold mb-2">Forgot Password?</h1>
+              <h1 className="text-2xl font-bold mb-2">Reset Password</h1>
               <p className="text-gray-600 dark:text-gray-400">
-                Enter your email address to reset your password
+                Enter your new password below
               </p>
             </div>
 
@@ -72,43 +84,40 @@ export default function ForgotPasswordPage() {
                 className="text-center"
               >
                 <div className="bg-success-100 dark:bg-success-900/30 text-success-600 dark:text-success-400 p-4 rounded-lg mb-6">
-                  Check your email for password reset instructions
+                  Password successfully reset. Redirecting to login...
                 </div>
-<Link href="/auth/login" className="w-full inline-block">
-  <Button className="w-full" variant="outline">
-    Return to Login
-  </Button>
-</Link>
               </motion.div>
             ) : (
               <form onSubmit={handleSubmit} className="space-y-6">
                 <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Email Address
-                  </label>
+                  <label className="block text-sm font-medium mb-2">New Password</label>
                   <div className="relative">
-                    <Mail className="absolute left-3 top-3 w-5 h-5 text-gray-400" />
+                    <Lock className="absolute left-3 top-3 w-5 h-5 text-gray-400" />
                     <input
-                      type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
+                      type="password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
                       className="w-full pl-10 pr-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-800"
-                      placeholder="you@example.com"
                       required
                     />
                   </div>
                 </div>
-
-                {error && (
-                  <p className="text-error-600 text-sm">{error}</p>
-                )}
-
-                <Button
-                  type="submit"
-                  disabled={isLoading}
-                  className="w-full"
-                >
-                  {isLoading ? 'Sending...' : 'Reset Password'}
+                <div>
+                  <label className="block text-sm font-medium mb-2">Confirm Password</label>
+                  <div className="relative">
+                    <Lock className="absolute left-3 top-3 w-5 h-5 text-gray-400" />
+                    <input
+                      type="password"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      className="w-full pl-10 pr-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-800"
+                      required
+                    />
+                  </div>
+                </div>
+                {error && <p className="text-error-600 text-sm">{error}</p>}
+                <Button type="submit" disabled={isLoading} className="w-full">
+                  {isLoading ? 'Resetting...' : 'Reset Password'}
                 </Button>
               </form>
             )}


### PR DESCRIPTION
## Summary
- hook up password reset route in backend
- send proper reset link in password reset email
- implement forgot password call in frontend
- add reset password page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run tsc` in backend *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6860059356a08323aa9348d768be95fd